### PR TITLE
Restrict children for a node, using plugins.

### DIFF
--- a/fluent_pages/adminui/urlnodeparentadmin.py
+++ b/fluent_pages/adminui/urlnodeparentadmin.py
@@ -81,13 +81,39 @@ class UrlNodeParentAdmin(MultiSiteAdminMixin, TranslatableAdmin, PolymorphicMPTT
         """
         # The arguments are made optional, to support both django-polymorphic 0.5 and 0.6
         from fluent_pages.extensions import page_type_pool
+        can_have_children = None
+        child_types = None
+
+        if request is not None:
+            parent = request.GET.get(self.model._mptt_meta.parent_attr, None)
+            # if we have a parent check to see if it exists and get can_have_children
+            if parent is not None:
+                try:
+                    parent_instance = self.base_model.objects.get(pk=parent)
+                    can_have_children = parent_instance.can_have_children
+                    child_types = parent_instance.get_child_types()
+                except self.base_model.DoesNotExist:
+                    pass
 
         priorities = {}
         choices = []
-        for plugin in page_type_pool.get_plugins():
-            ct = ContentType.objects.get_for_model(plugin.model)
-            choices.append((ct.id, plugin.verbose_name))
-            priorities[ct.id] = plugin.sort_priority
+        def fill_choices(filter=lambda x: True):
+            for plugin in page_type_pool.get_plugins():
+                ct_id = ContentType.objects.get_for_model(plugin.model).id
+                if not filter(ct_id):
+                    continue
+                choices.append((ct_id, plugin.verbose_name))
+                priorities[ct_id] = plugin.sort_priority
+
+        if can_have_children is not None:
+            if can_have_children:
+                if len(child_types) == 0:
+                    fill_choices()
+                else:
+                    # filter the choices
+                    fill_choices(lambda ct_id: ct_id in child_types)
+        else: # all choices
+            fill_choices()
 
         choices.sort(key=lambda choice: (priorities[choice[0]], choice[1]))
         return choices

--- a/fluent_pages/extensions/pagetypebase.py
+++ b/fluent_pages/extensions/pagetypebase.py
@@ -86,6 +86,10 @@ class PageTypePlugin(with_metaclass(forms.MediaDefiningClass, object)):
     #: Defines whether users are allowed to place sub pages below this node. When :attr:`is_file` is ``True``, this is never possible.
     can_have_children = True
 
+    #: Defines which pages can be children of this node.
+    #: List of values similar to those values accepted in a model ForeignKey.
+    child_types = []
+
     #: .. versionadded:: 0.9
     #: Tell whether the page type should be displayed in the sitemaps by default.
     #: This value can be changed for most pages in the admin interface.

--- a/fluent_pages/models/db.py
+++ b/fluent_pages/models/db.py
@@ -273,6 +273,18 @@ class UrlNode(with_metaclass(URLNodeMetaClass, PolymorphicMPTTModel, Translatabl
 
 
     @property
+    def child_types(self):
+        """
+        Return a list of content type ids of nodes that can be children of
+        this node.
+        """
+        # Redefine the model constant 'child_types' as property
+        # that access the plugin registration system,
+        plugin = self.plugin
+        return plugin.child_types
+
+
+    @property
     def plugin(self):
         """
         Access the parent plugin which renders this model.
@@ -285,6 +297,14 @@ class UrlNode(with_metaclass(URLNodeMetaClass, PolymorphicMPTTModel, Translatabl
             return page_type_pool._get_plugin_by_content_type(self.polymorphic_ctype_id)
         else:
             return page_type_pool.get_plugin_by_model(self.__class__)
+
+
+    @property
+    def page_key(self):
+        """
+        Ensure get_child_types is run once per plugin model.
+        """
+        return repr(self.plugin.model)
 
 
     # ---- Custom behavior ----

--- a/fluent_pages/tests/__init__.py
+++ b/fluent_pages/tests/__init__.py
@@ -8,3 +8,4 @@ from .menu import MenuTests
 from .modeldata import ModelDataTests
 from .plugins import PluginTests, PluginUrlTests
 from .templatetags import TemplateTagTests
+from .admintests import AdminTests

--- a/fluent_pages/tests/admintests.py
+++ b/fluent_pages/tests/admintests.py
@@ -1,0 +1,74 @@
+from django.contrib.contenttypes.models import ContentType
+from django.core.cache import cache
+from fluent_pages.models import Page
+from fluent_pages.tests.utils import AppTestCase
+from fluent_pages.tests.testapp.models import (
+    SimpleTextPage, PlainTextFile, WebShopPage, ChildTypesPage)
+from fluent_utils.django_compat import get_user_model
+
+class AdminTests(AppTestCase):
+
+    def setUp(self):
+        # Need to make sure that django-parler's cache isn't reused,
+        # because the transaction is rolled back on each test method.
+        cache.clear()
+        # Need to make a staff member and login
+        User = get_user_model()
+        self.username = 'a'
+        self.email = 'ab@example.com'
+        self.password = 'b'
+        self.test_user = User.objects.create_user(self.username, self.email, self.password)
+        self.test_user.is_staff = True
+        self.test_user.save()
+        login = self.client.login(username=self.username, password=self.password)
+        self.assertEqual(login, True)
+
+    @classmethod
+    def setUpTree(cls):
+        cls.root = SimpleTextPage.objects.create(title="Home", slug="home", status=SimpleTextPage.PUBLISHED, author=cls.user)
+        cls.root2 = ChildTypesPage.objects.create(title="Root2", slug="root2", status=ChildTypesPage.PUBLISHED, author=cls.user)
+
+    def test_child_types(self):
+        """test that all child types are created and correct"""
+        ids = set([
+            self.root.polymorphic_ctype_id,
+            self.root2.polymorphic_ctype_id,
+            ContentType.objects.get_for_model(PlainTextFile).id,
+            ContentType.objects.get_for_model(WebShopPage).id,
+        ])
+        childtypes = set(self.root2.get_child_types())
+        self.assertEqual(len(ids), len(ids | childtypes))
+
+    def move_mode(self):
+        """Make root a child of root2"""
+        resp = self.client.post('/admin/fluent_pages/page/api/node-moved/', {
+            'moved_id': self.root.id,
+            'target_id': self.root2.id,
+            'position': 'inside',
+            'previous_parent_id': 0
+        })
+
+    def test_allowed(self):
+        """"test the move with no modifications to child types"""
+        # try the move
+        self.move_mode()
+        # refresh objects
+        self.root = Page.objects.get(pk=self.root.pk)
+        self.root2 = Page.objects.get(pk=self.root2.pk)
+
+        self.assertTrue(self.root.url.startswith(self.root2.url))
+
+    def test_not_allowed(self):
+        """"test the move after removing child from allowed child types"""
+        # modify the childtypes cache
+        page_key = self.root2.page_key
+        self.root2._PolymorphicMPTTModel__child_types[page_key].remove(
+            self.root.polymorphic_ctype_id)
+        # try the move
+        self.move_mode()
+        # refresh objects
+        self.root = Page.objects.get(pk=self.root.pk)
+        self.root2 = Page.objects.get(pk=self.root2.pk)
+
+        self.assertFalse(self.root.url.startswith(self.root2.url))
+

--- a/fluent_pages/tests/testapp/migrations/0001_initial.py
+++ b/fluent_pages/tests/testapp/migrations/0001_initial.py
@@ -38,6 +38,19 @@ class Migration(migrations.Migration):
             bases=('fluent_pages.htmlpage',),
         ),
         migrations.CreateModel(
+            name='ChildTypesPage',
+            fields=[
+                ('urlnode_ptr', models.OneToOneField(auto_created=True, parent_link=True, serialize=False, primary_key=True, to='fluent_pages.UrlNode')),
+                ('contents', models.TextField(verbose_name='Contents')),
+            ],
+            options={
+                'db_table': 'pagetype_testapp_childtypespage',
+                'verbose_name_plural': 'Plain text pages',
+                'verbose_name': 'Plain text page',
+            },
+            bases=('fluent_pages.htmlpage',),
+        ),
+        migrations.CreateModel(
             name='WebShopPage',
             fields=[
                 ('urlnode_ptr', models.OneToOneField(auto_created=True, parent_link=True, serialize=False, primary_key=True, to='fluent_pages.UrlNode')),

--- a/fluent_pages/tests/testapp/models.py
+++ b/fluent_pages/tests/testapp/models.py
@@ -10,6 +10,15 @@ class SimpleTextPage(HtmlPage):
         app_label = 'testapp'
 
 
+class ChildTypesPage(HtmlPage):
+    contents = models.TextField("Contents")
+
+    class Meta:
+        verbose_name = "Plain text page"
+        verbose_name_plural = "Plain text pages"
+        app_label = 'testapp'
+
+
 class PlainTextFile(Page):
     content = models.TextField("Contents")
 

--- a/fluent_pages/tests/testapp/page_type_plugins.py
+++ b/fluent_pages/tests/testapp/page_type_plugins.py
@@ -1,6 +1,7 @@
 from django.http import HttpResponse
 from fluent_pages.extensions import page_type_pool, PageTypePlugin
-from fluent_pages.tests.testapp.models import SimpleTextPage, PlainTextFile, WebShopPage
+from fluent_pages.tests.testapp.models import (
+    SimpleTextPage, PlainTextFile, WebShopPage, ChildTypesPage)
 
 
 @page_type_pool.register
@@ -10,6 +11,18 @@ class SimpleTextPagePlugin(PageTypePlugin):
     """
     model = SimpleTextPage
     render_template = "testapp/simpletextpage.html"
+
+
+@page_type_pool.register
+class ChildTypesPagePlugin(PageTypePlugin):
+    """
+    Place a simple page in the page tree.
+    """
+    model = ChildTypesPage
+    render_template = "testapp/simpletextpage.html"
+
+    child_types = ['self', 'SimpleTextPage', 'testapp.PlainTextFile',
+                   WebShopPage]
 
 
 @page_type_pool.register

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist=
+
     py33-django17,
     py27-django17,
 
@@ -10,6 +11,17 @@ envlist=
     py33-django15,
     py27-django15,
     py26-django15,
+
+    py33-django17-51,
+    py27-django17-51,
+
+    py33-django16-51,
+    py27-django16-51,
+    py26-django16-51,
+
+    py33-django15-51,
+    py27-django15-51,
+    py26-django15-51,
 
     docs
 
@@ -64,3 +76,53 @@ deps =
     Sphinx
     -r{toxinidir}/docs/_ext/djangodummy/requirements.txt
 commands = sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
+
+
+
+[testenv:py27-django17-51]
+basepython=python2.7
+deps=
+    django==1.7.1
+    git+https://github.com/vinnyrose/django-polymorphic-tree@restrict_children_2#egg=django-polymorphic-tree
+
+[testenv:py33-django17-51]
+basepython=python3.3
+deps=
+    django==1.7.1
+    git+https://github.com/vinnyrose/django-polymorphic-tree@restrict_children_2#egg=django-polymorphic-tree
+
+[testenv:py26-django16-51]
+basepython=python2.6
+deps=
+    django==1.6.5
+    git+https://github.com/vinnyrose/django-polymorphic-tree@restrict_children_2#egg=django-polymorphic-tree
+
+[testenv:py27-django16-51]
+basepython=python2.7
+deps=
+    django==1.6.5
+    git+https://github.com/vinnyrose/django-polymorphic-tree@restrict_children_2#egg=django-polymorphic-tree
+
+[testenv:py33-django16-51]
+basepython=python3.3
+deps=
+    django==1.6.5
+    git+https://github.com/vinnyrose/django-polymorphic-tree@restrict_children_2#egg=django-polymorphic-tree
+
+[testenv:py26-django15-51]
+basepython=python2.6
+deps=
+    django==1.5.8
+    git+https://github.com/vinnyrose/django-polymorphic-tree@restrict_children_2#egg=django-polymorphic-tree
+
+[testenv:py27-django15-51]
+basepython=python2.7
+deps=
+    django==1.5.8
+    git+https://github.com/vinnyrose/django-polymorphic-tree@restrict_children_2#egg=django-polymorphic-tree
+
+[testenv:py33-django15-51]
+basepython=python3.3
+deps=
+    django==1.5.8
+    git+https://github.com/vinnyrose/django-polymorphic-tree@restrict_children_2#egg=django-polymorphic-tree


### PR DESCRIPTION
Ensure get_child_types is run once per plugin model.

Based on https://github.com/edoburu/django-polymorphic-tree/pull/29

Fixes #31

Added some tests and temporary tox runs.